### PR TITLE
Ox suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,15 @@ Go implementation of using HTTPS Everywhere rule sets to send traffic over HTTPS
 Example usage:
 
 ```go
+import "url"
 import "github.com/getlantern/httpseverywhere"
 
 ...
 
-httpURL := "http://name.com"
-https, err := httpseverywhere.New()
-if err != nil {
-	log.Errorf("Could not load HTTPS Everywhere? %v", err)
-	return
-}
-httpsURL, changed := https(httpURL)
+httpURL, _ := url.Parse("http://name.com")
+httpsURL, changed := httpseverywhere.Rewrite(httpURL)
 if changed {
-	// Redirect to httpsURL 
+	// Redirect to httpsURL
 	...
 }
 ```

--- a/httpseverywhere_test.go
+++ b/httpseverywhere_test.go
@@ -311,6 +311,16 @@ func newHTTPS(rules string) (rewrite, map[string]*Targets) {
 	return h.rewrite, hostsToTargets
 }
 
+func BenchmarkNoMatch(b *testing.B) {
+	h := newSync()
+
+	url := "http://unknowndomainthatshouldnotmatch.com"
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		h(toURL(url))
+	}
+}
+
 func toURL(urlStr string) *url.URL {
 	u, _ := url.Parse(urlStr)
 	return u


### PR DESCRIPTION
Benchmark results look good:

```
go test -run blah -bench NoMatch
DEBUG httpseverywhere-deserializer: deserializer.go:34 Loaded HTTPS Everywhere in 381.843858ms
DEBUG httpseverywhere-deserializer: deserializer.go:34 Loaded HTTPS Everywhere in 392.661905ms
BenchmarkNoMatch-4   	DEBUG httpseverywhere-deserializer: deserializer.go:34 Loaded HTTPS Everywhere in 280.557437ms
DEBUG httpseverywhere-deserializer: deserializer.go:34 Loaded HTTPS Everywhere in 249.952813ms
DEBUG httpseverywhere-deserializer: deserializer.go:34 Loaded HTTPS Everywhere in 336.353195ms
 1000000	      1599 ns/op
PASS
ok  	github.com/getlantern/httpseverywhere	5.419s
```